### PR TITLE
bind database to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: "mvertes/alpine-mongo"
     restart: always
     ports:
-      - "27017:27017"
+      - "127.0.0.1:27017:27017"
     volumes:
       - mongodb:/data/db
 
@@ -12,7 +12,7 @@ services:
     image: "postgres:9.2-alpine"
     # restart: always
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
Safer default config if the whole compose is exposed to the internet, let's keep postgre and mongo to ourselves.